### PR TITLE
Default policy extension

### DIFF
--- a/StepStack/Abstractions/IRetryPolicyFactoryResolver.cs
+++ b/StepStack/Abstractions/IRetryPolicyFactoryResolver.cs
@@ -3,7 +3,8 @@
 internal interface IRetryPolicyFactoryResolver
 {
     string CurrentFactoryName { get; }
-        void UseDefault();
-        void Select(string factoryName);
-        IRetryPolicyFactory Resolve();
+    void UseDefault();
+    void Select(string factoryName);
+    IRetryPolicyFactory Resolve();
+    void SetDefaultFactoryName(string name);
 }

--- a/StepStack/Extensions/ObjectCollectionExtensions.cs
+++ b/StepStack/Extensions/ObjectCollectionExtensions.cs
@@ -12,6 +12,15 @@ public static class ObjectCollectionExtensions
     public static IStrategyRegistration RegisterRetryPolicyFactory<TRetryPolicyFactory>(this IObjectContainer objectContainer, string name)
         where TRetryPolicyFactory : class, IRetryPolicyFactory =>
         objectContainer.RegisterTypeAs<TRetryPolicyFactory, IRetryPolicyFactory>(name.ToLower());
+
+    public static void RegisterRetryPolicyAsDefaultFactory<TRetryPolicyFactory>(this IObjectContainer objectContainer, string name)
+        where TRetryPolicyFactory : class, IRetryPolicyFactory
+    {
+        objectContainer.RegisterTypeAs<TRetryPolicyFactory, IRetryPolicyFactory>(name.ToLower());
+
+        var policyFactory = objectContainer.Resolve<IRetryPolicyFactoryResolver>();
+        policyFactory.SetDefaultFactoryName(name);
+    }
     
     public static IRetryPolicyFactory ResolveRetryPolicyFactory(this IObjectContainer objectContainer, string name) =>
         objectContainer.Resolve<IRetryPolicyFactory>(name.ToLower());

--- a/StepStack/RetryPolicyFactoryResolver.cs
+++ b/StepStack/RetryPolicyFactoryResolver.cs
@@ -15,7 +15,6 @@ internal sealed class RetryPolicyFactoryResolver : IRetryPolicyFactoryResolver
         _objectContainer = objectContainer;
     }
 
-
     public string CurrentFactoryName
     {
         get

--- a/StepStack/RetryPolicyFactoryResolver.cs
+++ b/StepStack/RetryPolicyFactoryResolver.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Linq;
 using BoDi;
 using EzSpecflow.Abstractions;
 using EzSpecflow.Extensions;
@@ -30,7 +28,7 @@ internal sealed class RetryPolicyFactoryResolver : IRetryPolicyFactoryResolver
             UseDefault();
             return;
         }
-        
+
         CurrentFactoryName = factoryName;
     }
 
@@ -39,5 +37,10 @@ internal sealed class RetryPolicyFactoryResolver : IRetryPolicyFactoryResolver
         var resolvedFactory = _objectContainer.ResolveRetryPolicyFactory(CurrentFactoryName);
         Console.WriteLine($"Resolved Retry Policy Factory: {resolvedFactory.GetType().FullName}");
         return resolvedFactory;
+    }
+
+    public void SetDefaultFactoryName(string defaultFactoryName)
+    {
+        DefaultFactoryName = defaultFactoryName;
     }
 }


### PR DESCRIPTION
Adds extension method to allow for a user defined and named default policy to be specified.

e.g.

```
[BeforeScenario(Order = 2)]
public void RegisterStepStackPolicy()
{
    this.objectContainer.RegisterRetryPolicyAsDefaultFactory<CustomRetryPolicyFactory>("myPolicy");
}
```

